### PR TITLE
Allow basic credential to override issued credential name

### DIFF
--- a/basic-credential.json
+++ b/basic-credential.json
@@ -21,7 +21,7 @@
       "type": "string",
       "description": "The email of the credential holder."
     },
-    "title": {
+    "credentialName": {
       "title": "Credential Title",
       "type": "string",
       "description": "The title of the credential."


### PR DESCRIPTION
Certs behaviour is if `credentialName` is set then it will use that as the credential name and exclude it from the subject, a workaround because of no proper schema creator 